### PR TITLE
Create Detail SwiftUI View

### DIFF
--- a/CleanArchWithUIKitDemo.xcodeproj/project.pbxproj
+++ b/CleanArchWithUIKitDemo.xcodeproj/project.pbxproj
@@ -42,6 +42,7 @@
 		CF0E5AED8B85A6F657A494EB /* MainExchangeRateListRepository.swift in Sources */ = {isa = PBXBuildFile; fileRef = 83C33EDD9812C9E00F70A800 /* MainExchangeRateListRepository.swift */; };
 		CF76714FE2DFDA29A6296040 /* HTTPClient.swift in Sources */ = {isa = PBXBuildFile; fileRef = C7A12C60B3A5B0B5B231EDE0 /* HTTPClient.swift */; };
 		CF893DAC2BC45494AE96CAEA /* ApiConfig.swift in Sources */ = {isa = PBXBuildFile; fileRef = 91CB000339FF729FA8902297 /* ApiConfig.swift */; };
+		D0C932190DEE7539C24965F9 /* ExchangeRateDetailView.swift in Sources */ = {isa = PBXBuildFile; fileRef = E8E801C93653BBE40E71CDCF /* ExchangeRateDetailView.swift */; };
 		D2C307C5FCE587DDE8A010DE /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = DC4B9F6315A8B7267BFDF7CF /* Assets.xcassets */; };
 		E5A08047553028F2FE83AF94 /* ExchangeRateListRepository.swift in Sources */ = {isa = PBXBuildFile; fileRef = 99D7A78B293EA0BDED992FDD /* ExchangeRateListRepository.swift */; };
 		E5DA4704E8E285E13FBB096E /* MockEntity.swift in Sources */ = {isa = PBXBuildFile; fileRef = D91CEDF4DF3D93B35F061669 /* MockEntity.swift */; };
@@ -118,6 +119,7 @@
 		DC4B9F6315A8B7267BFDF7CF /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
 		DD05BC59B4CDE5723BA274E1 /* ExchangeRateDetailCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExchangeRateDetailCoordinator.swift; sourceTree = "<group>"; };
 		E142D1969B12EC63C98A99F3 /* ExchangeRateDetailViewControllerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExchangeRateDetailViewControllerTests.swift; sourceTree = "<group>"; };
+		E8E801C93653BBE40E71CDCF /* ExchangeRateDetailView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExchangeRateDetailView.swift; sourceTree = "<group>"; };
 		ECA0B40846574AF0A14A5A10 /* XCTestCase+MemoryLeakTracking.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "XCTestCase+MemoryLeakTracking.swift"; sourceTree = "<group>"; };
 		ECADFA09F48B1D7A2FA9A9E9 /* ExchangeRateListViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExchangeRateListViewModel.swift; sourceTree = "<group>"; };
 		EE7CDC4B8BF8AC08D7511B97 /* ExchangeRateListApi.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExchangeRateListApi.swift; sourceTree = "<group>"; };
@@ -317,6 +319,7 @@
 		994DF322DFDFEB4DBDCFBD2B /* ExchangeRateDetail */ = {
 			isa = PBXGroup;
 			children = (
+				E8E801C93653BBE40E71CDCF /* ExchangeRateDetailView.swift */,
 				20D48D504DAABA67EA47D8D9 /* ExchangeRateDetailViewController.swift */,
 				72134A2642FB0FCD65B5D176 /* ExchangeRateDetailViewModel.swift */,
 			);
@@ -603,6 +606,7 @@
 				BE4AFE404A67B76651B29109 /* ExchangeRateDTO+Mapping.swift in Sources */,
 				037D2641AD08F44A9BCEA378 /* ExchangeRateDetailCoordinator.swift in Sources */,
 				F038E5206311EDD303F2C064 /* ExchangeRateDetailDIContainer.swift in Sources */,
+				D0C932190DEE7539C24965F9 /* ExchangeRateDetailView.swift in Sources */,
 				91FDD58E7AB3DF6745C447B8 /* ExchangeRateDetailViewController.swift in Sources */,
 				21883DAEBC13401F0D0C3763 /* ExchangeRateDetailViewModel.swift in Sources */,
 				518DD42AFB672D323296CDE3 /* ExchangeRateEntity.swift in Sources */,

--- a/CleanArchWithUIKitDemo/Application/Coordinator/Coordinator.swift
+++ b/CleanArchWithUIKitDemo/Application/Coordinator/Coordinator.swift
@@ -23,3 +23,8 @@ public extension Coordinator {
         childCoordinators = childCoordinators.filter { $0 !== child }
     }
 }
+
+public enum PresentationView: CaseIterable {
+    case UIKit
+    case SwiftUI
+}

--- a/CleanArchWithUIKitDemo/Application/Coordinator/ExchangeRateDetailCoordinator.swift
+++ b/CleanArchWithUIKitDemo/Application/Coordinator/ExchangeRateDetailCoordinator.swift
@@ -14,8 +14,10 @@ public protocol ExchangeRateDetailCoordinatorDelegate: AnyObject {
 public final class ExchangeRateDetailCoordinator: Coordinator {
     public struct Params {
         let rateEntity: ExchangeRateEntity.RateEntity
-        public init(rateEntity: ExchangeRateEntity.RateEntity) {
+        let view: PresentationView
+        public init(rateEntity: ExchangeRateEntity.RateEntity, view: PresentationView) {
             self.rateEntity = rateEntity
+            self.view = view
         }
     }
 
@@ -32,7 +34,13 @@ public final class ExchangeRateDetailCoordinator: Coordinator {
     }
 
     public func start() {
-        navigationController.pushViewController(makeExchangeRateDetailView(), animated: false)
+        let view = switch param.view {
+        case .UIKit:
+            makeExchangeRateDetailViewController()
+        case .SwiftUI:
+            makeExchangeRateDetailView()
+        }
+        navigationController.pushViewController(view, animated: false)
     }
 }
 

--- a/CleanArchWithUIKitDemo/Application/Coordinator/ExchangeRateDetailCoordinator.swift
+++ b/CleanArchWithUIKitDemo/Application/Coordinator/ExchangeRateDetailCoordinator.swift
@@ -32,7 +32,7 @@ public final class ExchangeRateDetailCoordinator: Coordinator {
     }
 
     public func start() {
-        navigationController.pushViewController(makeExchangeRateDetailViewController(), animated: false)
+        navigationController.pushViewController(makeExchangeRateDetailView(), animated: false)
     }
 }
 
@@ -44,14 +44,10 @@ extension ExchangeRateDetailCoordinator: ExchangeRateDetailViewModelDelegate {
 
 private extension ExchangeRateDetailCoordinator {
     func makeExchangeRateDetailViewController() -> UIViewController {
-        guard let vc = dependencies.makeExchangeRateDetailViewController(param: param) as? ExchangeRateDetailViewController else {
-            fatalError("Casting to ViewController fail")
-        }
-        vc.viewModel.delegate = self
-        return vc
+        dependencies.makeExchangeRateDetailViewController(param: param, delegate: self)
     }
 
     func makeExchangeRateDetailView() -> UIViewController {
-        dependencies.makeExchangeRateDetailView(param: param)
+        dependencies.makeExchangeRateDetailView(param: param, delegate: self)
     }
 }

--- a/CleanArchWithUIKitDemo/Application/Coordinator/ExchangeRateDetailCoordinator.swift
+++ b/CleanArchWithUIKitDemo/Application/Coordinator/ExchangeRateDetailCoordinator.swift
@@ -32,16 +32,26 @@ public final class ExchangeRateDetailCoordinator: Coordinator {
     }
 
     public func start() {
-        guard let vc = dependencies.makeExchangeRateDetailViewController(param: param) as? ExchangeRateDetailViewController else {
-            fatalError("Casting to ViewController fail")
-        }
-        vc.viewModel.delegate = self
-        navigationController.pushViewController(vc, animated: false)
+        navigationController.pushViewController(makeExchangeRateDetailViewController(), animated: false)
     }
 }
 
 extension ExchangeRateDetailCoordinator: ExchangeRateDetailViewModelDelegate {
     public func dismiss() {
         delegate?.dismiss(self)
+    }
+}
+
+private extension ExchangeRateDetailCoordinator {
+    func makeExchangeRateDetailViewController() -> UIViewController {
+        guard let vc = dependencies.makeExchangeRateDetailViewController(param: param) as? ExchangeRateDetailViewController else {
+            fatalError("Casting to ViewController fail")
+        }
+        vc.viewModel.delegate = self
+        return vc
+    }
+
+    func makeExchangeRateDetailView() -> UIViewController {
+        dependencies.makeExchangeRateDetailView(param: param)
     }
 }

--- a/CleanArchWithUIKitDemo/Application/Coordinator/ExchangeRateListCoordinator.swift
+++ b/CleanArchWithUIKitDemo/Application/Coordinator/ExchangeRateListCoordinator.swift
@@ -8,24 +8,39 @@
 import UIKit
 
 public final class ExchangeRateListCoordinator: Coordinator {
+    public struct Params {
+        let view: PresentationView
+        public init(view: PresentationView) {
+            self.view = view
+        }
+    }
+
     public var navigationController: UINavigationController
     public var childCoordinators: [Coordinator] = []
     private let dependencies: ExchangeRateListCoordinatorDependencies
+    private let param: Params
 
-    public init(navigationController: UINavigationController, dependencies: ExchangeRateListCoordinatorDependencies) {
+    public init(navigationController: UINavigationController, dependencies: ExchangeRateListCoordinatorDependencies, param: Params) {
         self.navigationController = navigationController
         self.dependencies = dependencies
+        self.param = param
     }
 
     public func start() {
-        self.navigationController.pushViewController(makeExchangeRateListViewController(), animated: false)
+        let view = switch self.param.view {
+        case .UIKit:
+            makeExchangeRateListViewController()
+        case .SwiftUI:
+            makeExchangeRateListView()
+        }
+        self.navigationController.pushViewController(view, animated: false)
     }
 }
 
 extension ExchangeRateListCoordinator: ExchangeRateListViewModelDelegate {
     public func goToDetail(rate: ExchangeRateEntity.RateEntity) {
         let diContainer = self.dependencies.makeExchangeRateDetailDIContainer()
-        let coordinator = diContainer.makeExchangeRateDetailCoordinator(navigationController: self.navigationController, param: ExchangeRateDetailCoordinator.Params(rateEntity: rate))
+        let coordinator = diContainer.makeExchangeRateDetailCoordinator(navigationController: self.navigationController, param: ExchangeRateDetailCoordinator.Params(rateEntity: rate, view: self.param.view))
         coordinator.delegate = self
         add(child: coordinator)
         coordinator.start()

--- a/CleanArchWithUIKitDemo/Application/Coordinator/ExchangeRateListCoordinator.swift
+++ b/CleanArchWithUIKitDemo/Application/Coordinator/ExchangeRateListCoordinator.swift
@@ -40,14 +40,10 @@ extension ExchangeRateListCoordinator: ExchangeRateDetailCoordinatorDelegate {
 
 private extension ExchangeRateListCoordinator {
     func makeExchangeRateListViewController() -> UIViewController {
-        guard let vc = dependencies.makeExchangeRateListViewController() as? ExchangeRateListViewController else {
-            fatalError("Casting to ViewController fail")
-        }
-        vc.viewModel.delegate = self
-        return vc
+        self.dependencies.makeExchangeRateListViewController(delegate: self)
     }
 
     func makeExchangeRateListView() -> UIViewController {
-        self.dependencies.makeExchangeRateListView()
+        self.dependencies.makeExchangeRateListView(delegate: self)
     }
 }

--- a/CleanArchWithUIKitDemo/Application/DIContainer/AppDIContainer.swift
+++ b/CleanArchWithUIKitDemo/Application/DIContainer/AppDIContainer.swift
@@ -18,6 +18,6 @@ public final class AppDIContainer {
 extension AppDIContainer {
     func makeExchangeRateListDIContainer() -> ExchangeRateListDIContainer {
         let dependencies = ExchangeRateListDIContainer.Dependencies(loadDataLoader: loadDataLoader)
-        return ExchangeRateListDIContainer(dependencies: dependencies)
+        return ExchangeRateListDIContainer(dependencies: dependencies, view: .UIKit)
     }
 }

--- a/CleanArchWithUIKitDemo/Application/DIContainer/ExchangeRateDetailDIContainer.swift
+++ b/CleanArchWithUIKitDemo/Application/DIContainer/ExchangeRateDetailDIContainer.swift
@@ -5,6 +5,7 @@
 //  Created by Jill Chang on 2024/8/31.
 //
 
+import SwiftUI
 import UIKit
 
 public final class ExchangeRateDetailDIContainer {
@@ -17,6 +18,7 @@ public final class ExchangeRateDetailDIContainer {
 
 public protocol ExchangeRateDetailCoordinatorDependencies: AnyObject {
     func makeExchangeRateDetailViewController(param: ExchangeRateDetailCoordinator.Params) -> UIViewController
+    func makeExchangeRateDetailView(param: ExchangeRateDetailCoordinator.Params) -> UIViewController
 }
 
 extension ExchangeRateDetailDIContainer: ExchangeRateDetailCoordinatorDependencies {
@@ -25,5 +27,14 @@ extension ExchangeRateDetailDIContainer: ExchangeRateDetailCoordinatorDependenci
         let viewModel = ExchangeRateDetailViewModel(param: param)
         // VC
         return ExchangeRateDetailViewController(viewModel: viewModel)
+    }
+
+    public func makeExchangeRateDetailView(param: ExchangeRateDetailCoordinator.Params) -> UIViewController {
+        // VM
+        let viewModel = ExchangeRateDetailViewModel(param: param)
+        // VC
+        let view = ExchangeRateDetailView(viewModel: viewModel)
+
+        return UIHostingController(rootView: view)
     }
 }

--- a/CleanArchWithUIKitDemo/Application/DIContainer/ExchangeRateDetailDIContainer.swift
+++ b/CleanArchWithUIKitDemo/Application/DIContainer/ExchangeRateDetailDIContainer.swift
@@ -17,21 +17,23 @@ public final class ExchangeRateDetailDIContainer {
 }
 
 public protocol ExchangeRateDetailCoordinatorDependencies: AnyObject {
-    func makeExchangeRateDetailViewController(param: ExchangeRateDetailCoordinator.Params) -> UIViewController
-    func makeExchangeRateDetailView(param: ExchangeRateDetailCoordinator.Params) -> UIViewController
+    func makeExchangeRateDetailViewController(param: ExchangeRateDetailCoordinator.Params, delegate: ExchangeRateDetailViewModelDelegate?) -> UIViewController
+    func makeExchangeRateDetailView(param: ExchangeRateDetailCoordinator.Params, delegate: ExchangeRateDetailViewModelDelegate?) -> UIViewController
 }
 
 extension ExchangeRateDetailDIContainer: ExchangeRateDetailCoordinatorDependencies {
-    public func makeExchangeRateDetailViewController(param: ExchangeRateDetailCoordinator.Params) -> UIViewController {
+    public func makeExchangeRateDetailViewController(param: ExchangeRateDetailCoordinator.Params, delegate: ExchangeRateDetailViewModelDelegate?) -> UIViewController {
         // VM
         let viewModel = ExchangeRateDetailViewModel(param: param)
+        viewModel.delegate = delegate
         // VC
         return ExchangeRateDetailViewController(viewModel: viewModel)
     }
 
-    public func makeExchangeRateDetailView(param: ExchangeRateDetailCoordinator.Params) -> UIViewController {
+    public func makeExchangeRateDetailView(param: ExchangeRateDetailCoordinator.Params, delegate: ExchangeRateDetailViewModelDelegate?) -> UIViewController {
         // VM
         let viewModel = ExchangeRateDetailViewModel(param: param)
+        viewModel.delegate = delegate
         // VC
         let view = ExchangeRateDetailView(viewModel: viewModel)
 

--- a/CleanArchWithUIKitDemo/Application/DIContainer/ExchangeRateListDIContainer.swift
+++ b/CleanArchWithUIKitDemo/Application/DIContainer/ExchangeRateListDIContainer.swift
@@ -31,13 +31,13 @@ public final class ExchangeRateListDIContainer {
 
 /// make DIContainer or ViewController
 public protocol ExchangeRateListCoordinatorDependencies {
-    func makeExchangeRateListViewController() -> UIViewController
-    func makeExchangeRateListView() -> UIViewController
+    func makeExchangeRateListViewController(delegate: ExchangeRateListViewModelDelegate?) -> UIViewController
+    func makeExchangeRateListView(delegate: ExchangeRateListViewModelDelegate?) -> UIViewController
     func makeExchangeRateDetailDIContainer() -> ExchangeRateDetailDIContainer
 }
 
 extension ExchangeRateListDIContainer: ExchangeRateListCoordinatorDependencies {
-    public func makeExchangeRateListView() -> UIViewController {
+    public func makeExchangeRateListView(delegate: ExchangeRateListViewModelDelegate?) -> UIViewController {
         // Data layer
         let repository = MainExchangeRateListRepository(loadDataLoader: dependencies.loadDataLoader)
         // Mock
@@ -48,13 +48,14 @@ extension ExchangeRateListDIContainer: ExchangeRateListCoordinatorDependencies {
 
         // Presentation layer
         let vm = ExchangeRateListViewModel(usecase)
+        vm.delegate = delegate
 
         let view = ExchangeRateListView(viewModel: vm)
 
         return UIHostingController(rootView: view)
     }
 
-    public func makeExchangeRateListViewController() -> UIViewController {
+    public func makeExchangeRateListViewController(delegate: ExchangeRateListViewModelDelegate?) -> UIViewController {
         // Data layer
         let repository = MainExchangeRateListRepository(loadDataLoader: dependencies.loadDataLoader)
         // Mock
@@ -65,6 +66,7 @@ extension ExchangeRateListDIContainer: ExchangeRateListCoordinatorDependencies {
 
         // Presentation layer
         let vm = ExchangeRateListViewModel(usecase)
+        vm.delegate = delegate
 
         let view = ExchangeRateListViewController(viewModel: vm)
         return view

--- a/CleanArchWithUIKitDemo/Application/DIContainer/ExchangeRateListDIContainer.swift
+++ b/CleanArchWithUIKitDemo/Application/DIContainer/ExchangeRateListDIContainer.swift
@@ -17,15 +17,17 @@ public final class ExchangeRateListDIContainer {
     }
 
     private let dependencies: Dependencies
+    private let view: PresentationView
 
-    public init(dependencies: Dependencies) {
+    public init(dependencies: Dependencies, view: PresentationView) {
         self.dependencies = dependencies
+        self.view = view
     }
 
     // MARK: - Flow Coordinators
 
     public func makeExchangeRateListCoordinator(navigationController: UINavigationController) -> ExchangeRateListCoordinator {
-        ExchangeRateListCoordinator(navigationController: navigationController, dependencies: self)
+        ExchangeRateListCoordinator(navigationController: navigationController, dependencies: self, param: ExchangeRateListCoordinator.Params(view: view))
     }
 }
 

--- a/CleanArchWithUIKitDemo/Presentation/ExchangeRateDetail/ExchangeRateDetailView.swift
+++ b/CleanArchWithUIKitDemo/Presentation/ExchangeRateDetail/ExchangeRateDetailView.swift
@@ -7,10 +7,10 @@
 
 import SwiftUI
 
-struct ExchangeRateDetailView: View {
-    @ObservedObject var viewModel: ExchangeRateDetailViewModel
+public struct ExchangeRateDetailView: View {
+    @ObservedObject public var viewModel: ExchangeRateDetailViewModel
 
-    var body: some View {
+    public var body: some View {
         VStack {
             Text(viewModel.currencyText)
                 .font(.system(size: 34.0))
@@ -28,5 +28,5 @@ struct ExchangeRateDetailView: View {
 }
 
 #Preview {
-    ExchangeRateDetailView(viewModel: ExchangeRateDetailViewModel(param: ExchangeRateDetailCoordinator.Params(rateEntity: ExchangeRateEntity.RateEntity.mockValue)))
+    ExchangeRateDetailView(viewModel: ExchangeRateDetailViewModel(param: ExchangeRateDetailCoordinator.Params(rateEntity: ExchangeRateEntity.RateEntity.mockValue, view: .SwiftUI)))
 }

--- a/CleanArchWithUIKitDemo/Presentation/ExchangeRateDetail/ExchangeRateDetailView.swift
+++ b/CleanArchWithUIKitDemo/Presentation/ExchangeRateDetail/ExchangeRateDetailView.swift
@@ -1,0 +1,29 @@
+//
+//  ExchangeRateDetailView.swift
+//  CleanArchWithUIKitDemo
+//
+//  Created by Jill Chang on 2024/9/27.
+//
+
+import SwiftUI
+
+struct ExchangeRateDetailView: View {
+    @ObservedObject var viewModel: ExchangeRateDetailViewModel
+
+    var body: some View {
+        VStack {
+            Text(viewModel.currencyText)
+                .font(.system(size: 34.0))
+                .foregroundStyle(.black.opacity(0.5))
+                .padding(.vertical, 48)
+            Text(viewModel.rateText)
+                .font(.system(size: 24.0))
+                .foregroundStyle(.tint.opacity(0.7))
+            Spacer()
+        }
+    }
+}
+
+#Preview {
+    ExchangeRateDetailView(viewModel: ExchangeRateDetailViewModel(param: ExchangeRateDetailCoordinator.Params(rateEntity: ExchangeRateEntity.RateEntity.mockValue)))
+}

--- a/CleanArchWithUIKitDemo/Presentation/ExchangeRateDetail/ExchangeRateDetailView.swift
+++ b/CleanArchWithUIKitDemo/Presentation/ExchangeRateDetail/ExchangeRateDetailView.swift
@@ -21,6 +21,9 @@ struct ExchangeRateDetailView: View {
                 .foregroundStyle(.tint.opacity(0.7))
             Spacer()
         }
+        .onDisappear {
+            viewModel.input.viewWillDisappear()
+        }
     }
 }
 

--- a/CleanArchWithUIKitDemo/Presentation/ExchangeRateDetail/ExchangeRateDetailViewModel.swift
+++ b/CleanArchWithUIKitDemo/Presentation/ExchangeRateDetail/ExchangeRateDetailViewModel.swift
@@ -30,11 +30,11 @@ public protocol ExchangeRateDetailViewModelDelegate: AnyObject {
     func dismiss()
 }
 
-public final class ExchangeRateDetailViewModel: ExchangeRateDetailVMManager, ExchangeRateDetailVMOutput {
+public final class ExchangeRateDetailViewModel: ObservableObject, ExchangeRateDetailVMManager, ExchangeRateDetailVMOutput {
     public weak var delegate: ExchangeRateDetailViewModelDelegate?
 
-    @Published private var currencyText: String
-    @Published private var rateText: String
+    @Published private(set) var currencyText: String
+    @Published private(set) var rateText: String
 
     public init(param: ExchangeRateDetailCoordinator.Params) {
         currencyText = param.rateEntity.currencyText

--- a/CleanArchWithUIKitDemo/Presentation/ExchangeRateList/ExchangeRateListView.swift
+++ b/CleanArchWithUIKitDemo/Presentation/ExchangeRateList/ExchangeRateListView.swift
@@ -12,15 +12,22 @@ struct ExchangeRateListView: View {
 
     var body: some View {
         List(viewModel.rateEntity?.rates ?? []) { item in
-            VStack(alignment: .leading, spacing: 3) {
-                Text(item.currencyText)
-                    .foregroundColor(.primary)
-                    .font(.headline)
-                HStack {
-                    Label(item.rateText, systemImage: "dollarsign.bank.building")
+            HStack {
+                VStack(alignment: .leading) {
+                    Text(item.currencyText)
+                        .foregroundColor(.primary)
+                        .font(.headline)
+                    HStack {
+                        Label(item.rateText, systemImage: "dollarsign.bank.building")
+                    }
+                    .foregroundColor(.secondary)
+                    .font(.subheadline)
                 }
-                .foregroundColor(.secondary)
-                .font(.subheadline)
+                Spacer()
+            }
+            .contentShape(Rectangle())
+            .onTapGesture {
+                viewModel.onTapGesture(item)
             }
         }
         .onAppear {

--- a/CleanArchWithUIKitDemo/Presentation/ExchangeRateList/ExchangeRateListView.swift
+++ b/CleanArchWithUIKitDemo/Presentation/ExchangeRateList/ExchangeRateListView.swift
@@ -7,10 +7,10 @@
 
 import SwiftUI
 
-struct ExchangeRateListView: View {
+public struct ExchangeRateListView: View {
     @ObservedObject var viewModel: ExchangeRateListViewModel
 
-    var body: some View {
+    public var body: some View {
         List(viewModel.rateEntity?.rates ?? []) { item in
             HStack {
                 VStack(alignment: .leading) {

--- a/CleanArchWithUIKitDemo/Presentation/ExchangeRateList/ExchangeRateListViewModel.swift
+++ b/CleanArchWithUIKitDemo/Presentation/ExchangeRateList/ExchangeRateListViewModel.swift
@@ -110,6 +110,14 @@ extension ExchangeRateListViewModel: ExchangeRateListVMInput {
         guard let rate = rateEntity?.rates[row] else {
             return
         }
+        goToDetail(rate)
+    }
+
+    public func onTapGesture(_ rate: ExchangeRateEntity.RateEntity) {
+        goToDetail(rate)
+    }
+
+    private func goToDetail(_ rate: ExchangeRateEntity.RateEntity) {
         delegate?.goToDetail(rate: rate)
     }
 }

--- a/CleanArchWithUIKitDemoTests/Presentation/ExchangeRateDetail/ExchangeRateDetailCoordinatorTests.swift
+++ b/CleanArchWithUIKitDemoTests/Presentation/ExchangeRateDetail/ExchangeRateDetailCoordinatorTests.swift
@@ -6,28 +6,57 @@
 //
 
 import CleanArchWithUIKitDemo
+import SwiftUI
 import UIKit
 import XCTest
 
 class ExchangeRateDetailCoordinatorTests: XCTestCase {
     func testStart_ShouldPushInitialViewController() {
-        let sut = makeSUT()
+        for view in PresentationView.allCases {
+            pushInitialView(view: view)
+        }
+    }
+
+    private func pushInitialView(view: PresentationView) {
+        let sut = makeSUT(view: view)
 
         sut.start()
 
         let mockNavigationController = sut.navigationController as? MockNavigationController
-        XCTAssertEqual(mockNavigationController?.pushedViewControllers.count, 1, "Exactly one view controller should be pushed")
-        XCTAssertTrue(mockNavigationController?.pushedViewControllers.first is ExchangeRateDetailViewController, "The first pushed view controller should be of type ExchangeRateListViewController")
+        guard let firstViewController = mockNavigationController?.pushedViewControllers.first else {
+            XCTFail("Exactly one view controller should be pushed")
+            return
+        }
+
+        switch view {
+        case .UIKit:
+            XCTAssertTrue(firstViewController is ExchangeRateDetailViewController, "The first pushed view controller should be of type ExchangeRateDetailViewController")
+        case .SwiftUI:
+            XCTAssertTrue(firstViewController is UIHostingController<ExchangeRateDetailView>, "The first pushed view controller should be of type UIHostingController<ExchangeRateDetailView>")
+        }
     }
 
-    func test_trigger_dismiss() {
-        let sut = makeSUT()
+    func test_triggerViewController_dismiss() {
+        for view in PresentationView.allCases {
+            triggerViewDismiss(view: view)
+        }
+    }
+
+    private func triggerViewDismiss(view: PresentationView) {
+        let sut = makeSUT(view: view)
         let spy = SpyExchangeRateDetailCoordinatorDelegate()
         sut.delegate = spy
         sut.start()
 
-        let detailVC = (sut.navigationController as? MockNavigationController)?.pushedViewControllers.first as? ExchangeRateDetailViewController
-        detailVC?.viewModel.input.viewWillDisappear()
+        switch view {
+        case .UIKit:
+            let detailVC = (sut.navigationController as? MockNavigationController)?.pushedViewControllers.first as? ExchangeRateDetailViewController
+            detailVC?.viewModel.input.viewWillDisappear()
+
+        case .SwiftUI:
+            let detailView = ((sut.navigationController as? MockNavigationController)?.pushedViewControllers.first as? UIHostingController<ExchangeRateDetailView>)?.rootView
+            detailView?.viewModel.input.viewWillDisappear()
+        }
 
         XCTAssertEqual(spy.dismissCallCount, 1)
     }
@@ -41,11 +70,11 @@ private class SpyExchangeRateDetailCoordinatorDelegate: ExchangeRateDetailCoordi
 }
 
 private extension ExchangeRateDetailCoordinatorTests {
-    func makeSUT(file: StaticString = #filePath, line: UInt = #line) -> ExchangeRateDetailCoordinator {
+    func makeSUT(view: PresentationView, file: StaticString = #filePath, line: UInt = #line) -> ExchangeRateDetailCoordinator {
         let diContainer = ExchangeRateDetailDIContainer()
-        let coordinator = diContainer.makeExchangeRateDetailCoordinator(navigationController: MockNavigationController(), param: ExchangeRateDetailCoordinator.Params(rateEntity: ExchangeRateEntity.RateEntity.mockValue))
-        trackForMemoryLeaks(diContainer)
-        trackForMemoryLeaks(coordinator)
+        let coordinator = diContainer.makeExchangeRateDetailCoordinator(navigationController: MockNavigationController(), param: ExchangeRateDetailCoordinator.Params(rateEntity: ExchangeRateEntity.RateEntity.mockValue, view: view))
+        trackForMemoryLeaks(diContainer, file: file, line: line)
+        trackForMemoryLeaks(coordinator, file: file, line: line)
         return coordinator
     }
 }

--- a/CleanArchWithUIKitDemoTests/Presentation/ExchangeRateDetail/ExchangeRateDetailViewModelTests.swift
+++ b/CleanArchWithUIKitDemoTests/Presentation/ExchangeRateDetail/ExchangeRateDetailViewModelTests.swift
@@ -12,7 +12,7 @@ import XCTest
 class ExchangeRateDetailViewModelTests: XCTestCase {
     func test_output_currencyLabel() async {
         let predicateEntity = ExchangeRateEntity.RateEntity.mockValue
-        var (sut, cancellable) = makeSUT(param: ExchangeRateDetailCoordinator.Params(rateEntity: predicateEntity))
+        var (sut, cancellable) = makeSUT(param: ExchangeRateDetailCoordinator.Params(rateEntity: predicateEntity, view: .UIKit))
 
         let exp = expectation(description: "Wait for ExchangeRate Currency")
         sut.output.currencyTextPublished
@@ -26,7 +26,7 @@ class ExchangeRateDetailViewModelTests: XCTestCase {
 
     func test_output_rateLabel() async {
         let predicateEntity = ExchangeRateEntity.RateEntity.mockValue
-        var (sut, cancellable) = makeSUT(param: ExchangeRateDetailCoordinator.Params(rateEntity: predicateEntity))
+        var (sut, cancellable) = makeSUT(param: ExchangeRateDetailCoordinator.Params(rateEntity: predicateEntity, view: .UIKit))
 
         let exp = expectation(description: "Wait for ExchangeRate Rate")
         sut.output.rateTextPublished
@@ -40,7 +40,7 @@ class ExchangeRateDetailViewModelTests: XCTestCase {
 
     func test_input_viewWillDisappear() {
         let predicateEntity = ExchangeRateEntity.RateEntity.mockValue
-        let (sut, _) = makeSUT(param: ExchangeRateDetailCoordinator.Params(rateEntity: predicateEntity))
+        let (sut, _) = makeSUT(param: ExchangeRateDetailCoordinator.Params(rateEntity: predicateEntity, view: .UIKit))
 
         let spy = SpyExchangeRateDetailViewModelDelegate()
         sut.delegate = spy


### PR DESCRIPTION
- Coordinator: Separate make for UIKit and SwiftUI views.
- UIKit and SwiftUI: Share the same ViewModel.
- Adjust List View
    - onTap event
- Adjust unit test
    - List inject view type
    - Detail inject view type



This pull request addresses issue  #8.